### PR TITLE
Adiciona prompt de confirmação ao cancelar reserva

### DIFF
--- a/app/views/bookings/_owner_options.html.erb
+++ b/app/views/bookings/_owner_options.html.erb
@@ -17,5 +17,5 @@
 <% end %>
 
 <% if Date.today >= @booking.start_date + 2.days && @booking.confirmed? %>
-  <%= button_to "CANCELAR RESERVA", cancel_room_booking_path(@room) %>
+  <%= button_to "CANCELAR RESERVA", cancel_room_booking_path(@room), data: { turbo_confirm: "Cancelar reserva?" } %>
 <% end %>

--- a/app/views/bookings/_user_canceling.html.erb
+++ b/app/views/bookings/_user_canceling.html.erb
@@ -1,7 +1,7 @@
 <% if @booking.confirmed? && @booking.cancel_date > Date.today %>
   <div>
     <p>Você pode cancelar sua reserva até <strong><%= l(@booking.cancel_date) %></strong></p>
-    <%= button_to "CANCELAR RESERVA", cancel_room_booking_path(@room.id) %>
+    <%= button_to "CANCELAR RESERVA", cancel_room_booking_path(@room.id), data: { turbo_confirm: "Cancelar a reserva?" } %>
   </div>
 <% elsif @booking.confirmed? && @booking.cancel_date <= Date.today %>
   <div>


### PR DESCRIPTION
Uma janela de confirmação aparece tanto para hóspedes quanto para proprietários ao clicar em CANCELAR RESERVA