### PR TITLE
Configura CORS para GET nos endpoints da API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,9 +53,15 @@ gem "devise"
 # br_documents to validate CPF/CNPJ [https://github.com/asseinfo/br_documents]
 gem "br_documents"
 
+gem "rack-cors"
+
 group :development, :test do
-  # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[ mri mingw x64_mingw ]
+# See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
+gem "debug", platforms: %i[ mri mingw x64_mingw ]
+
+
+
+
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,9 +111,6 @@ GEM
     irb (1.8.3)
       rdoc
       reline (>= 0.3.8)
-    jbuilder (2.11.5)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
     loofah (2.21.4)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -150,6 +147,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.7.1)
     rack (2.2.8)
+    rack-cors (2.0.1)
+      rack (>= 2.0.0)
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8)
@@ -258,8 +257,8 @@ DEPENDENCIES
   debug
   devise
   importmap-rails
-  jbuilder
   puma (~> 5.0)
+  rack-cors
   rails (~> 7.0.8)
   rspec-rails
   selenium-webdriver

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,6 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins '*'
+    resource '*/api/*', headers: :any, methods: [:get]
+  end
+end


### PR DESCRIPTION
Habilita acesso externo somente para requisições GET nos endpoints da api