### PR TITLE
Adiciona mensagem no corpo da resposta

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -13,10 +13,10 @@ class Api::V1::ApiController < ActionController::API
   private
 
   def return_404
-    render status: 404
+    render status: 404, json: {"erro": "Recurso não encontrado"}
   end
 
   def return_500
-    render status: 500
+    render status: 500, json: {"erro": "Tente novamente mais tarde"}
   end
 end

--- a/spec/requests/api/inns_api_spec.rb
+++ b/spec/requests/api/inns_api_spec.rb
@@ -433,6 +433,7 @@ RSpec.describe "Inns API", type: :request do
       get "/api/v1/inns/#{inn.id}"
 
       expect(response).to have_http_status 500
+      expect(response.body).to include "Tente novamente mais tarde"
     end
   end
 


### PR DESCRIPTION
Em casos de erros da API a resposta contém uma mensagem genérica